### PR TITLE
 feat: 부산 교육청(학교) 지원센터 크롤링 기능 추가

### DIFF
--- a/src/main/java/com/helpcentercrawl/config/CrawlerValueSettings.java
+++ b/src/main/java/com/helpcentercrawl/config/CrawlerValueSettings.java
@@ -42,4 +42,23 @@ public class CrawlerValueSettings {
 
     @Value("${crawler.sites.changwon.password}")
     private String changwonPassword;
+
+    // 부산교육청-학교 사이트 설정
+    @Value("${crawler.sites.busan-school.name}")
+    private String busanSchoolName;
+
+    @Value("${crawler.sites.busan-school.login-url}")
+    private String busanSchoolLoginUrl;
+
+    @Value("${crawler.sites.busan-school.school-target-url}")
+    private String busanSchoolSchoolTargetUrl;
+
+    @Value("${crawler.sites.busan-school.kindergarten-target-url}")
+    private String busanSchoolKindergartenTargetUrl;
+
+    @Value("${crawler.sites.busan-school.username}")
+    private String busanSchoolUsername;
+
+    @Value("${crawler.sites.busan-school.password}")
+    private String busanSchoolPassword;
 }

--- a/src/main/java/com/helpcentercrawl/crawler/core/AbstractCrawler.java
+++ b/src/main/java/com/helpcentercrawl/crawler/core/AbstractCrawler.java
@@ -36,6 +36,7 @@ public abstract class AbstractCrawler implements SiteCrawler {
     private static final String LOCAL_CHROME_DRIVER_PATH = "src/main/resources/chromedriver/windows/chromedriver.exe";
     private static final String PROC_CHROME_DRIVER_PATH = "/usr/bin/chromedriver";
     private static final String SET_PROPERTY = "webdriver.chrome.driver";
+    private static final String PAGINATION_SELECTOR = ".pagination li a";
 
     /**
      * 템플릿 메서드 - 크롤링 전체 프로세스를 정의합니다.
@@ -110,7 +111,7 @@ public abstract class AbstractCrawler implements SiteCrawler {
 
     private static ChromeOptions getOptions() {
         ChromeOptions options = new ChromeOptions();
-        options.addArguments("--headless"); // Docker에서 실행 시 필요
+//        options.addArguments("--headless"); // Docker에서 실행 시 필요
         options.addArguments("--no-sandbox"); // Docker에서 필요
         options.addArguments("--disable-dev-shm-usage"); // Docker에서 필요
 
@@ -153,16 +154,14 @@ public abstract class AbstractCrawler implements SiteCrawler {
     /**
      * 여러 페이지의 데이터를 처리하는 공통 메서드
      *
-     * @param tableSelector      테이블 행 선택자
-     * @param paginationSelector 페이지네이션 선택자
-     * @param maxPageToCheck     확인할 최대 페이지 수
+     * @param tableSelector 테이블 행 선택자
      */
-    protected void processMultiplePages(String tableSelector, String paginationSelector, int maxPageToCheck) {
+    protected void processMultiplePages(String tableSelector) {
         // 페이지네이션 탐색
-        int maxPages = getMaxPagesCount(paginationSelector);
+        int maxPages = getMaxPagesCount();
 
-        // 각 페이지 탐색
-        for (int currentPage = 1; currentPage <= Math.min(maxPages, maxPageToCheck); currentPage++) {
+        // 각 페이지 탐색 현재 5페이지까지만 탐색
+        for (int currentPage = 1; currentPage <= Math.min(maxPages, 5); currentPage++) {
             if (currentPage > 1) {
                 navigateToPage(currentPage);
             }
@@ -175,11 +174,11 @@ public abstract class AbstractCrawler implements SiteCrawler {
     /**
      * 페이지 수 확인 공통 메서드
      */
-    protected int getMaxPagesCount(String paginationSelector) {
+    protected int getMaxPagesCount() {
         int maxPages = 1;
         try {
             // 페이지네이션 요소 찾기
-            List<WebElement> pagination = driver.findElements(By.cssSelector(paginationSelector));
+            List<WebElement> pagination = driver.findElements(By.cssSelector(PAGINATION_SELECTOR));
 
             // 페이지 수 파악 (마지막 페이지 번호 찾기)
             for (WebElement pageLink : pagination) {

--- a/src/main/java/com/helpcentercrawl/crawler/core/AbstractCrawler.java
+++ b/src/main/java/com/helpcentercrawl/crawler/core/AbstractCrawler.java
@@ -111,7 +111,7 @@ public abstract class AbstractCrawler implements SiteCrawler {
 
     private static ChromeOptions getOptions() {
         ChromeOptions options = new ChromeOptions();
-//        options.addArguments("--headless"); // Docker에서 실행 시 필요
+        options.addArguments("--headless"); // Docker에서 실행 시 필요
         options.addArguments("--no-sandbox"); // Docker에서 필요
         options.addArguments("--disable-dev-shm-usage"); // Docker에서 필요
 

--- a/src/main/java/com/helpcentercrawl/crawler/impl/BusanSchoolCrawler.java
+++ b/src/main/java/com/helpcentercrawl/crawler/impl/BusanSchoolCrawler.java
@@ -1,0 +1,137 @@
+package com.helpcentercrawl.crawler.impl;
+
+import com.helpcentercrawl.config.CrawlerValueSettings;
+import com.helpcentercrawl.crawler.core.AbstractCrawler;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class BusanSchoolCrawler extends AbstractCrawler {
+
+    public BusanSchoolCrawler(CrawlerValueSettings valueSettings) {
+        super(valueSettings);
+    }
+
+    @Override
+    public String getSiteName() {
+        return valueSettings.getBusanSchoolName();
+    }
+
+    @Override
+    protected void login() throws InterruptedException {
+        // 로그인 페이지로 이동
+        driver.get(valueSettings.getBusanSchoolLoginUrl());
+        log.info("부산교육청-학교 헬프센터 로그인 페이지 접속 완료");
+
+        try {
+            // 로그인 폼 요소들이 로드될 때까지 대기
+            wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("mberId")));
+
+            // 아이디 입력
+            WebElement idInput = driver.findElement(By.id("mberId"));
+            idInput.clear();
+            idInput.sendKeys(valueSettings.getBusanSchoolUsername());
+
+            // 비밀번호 입력
+            WebElement pwInput = driver.findElement(By.id("mberPassword"));
+            pwInput.clear();
+            pwInput.sendKeys(valueSettings.getBusanSchoolPassword());
+
+            // 로그인 버튼 클릭
+            WebElement loginButton = driver.findElement(By.cssSelector("a.btn_login"));
+            loginButton.click();
+
+            // 로그인 처리 대기
+            Thread.sleep(3000);
+
+            // 알림창이 뜨는지 확인 (로그인 성공 시 알림창이 표시됨)
+            try {
+                WebElement confirmButton = driver.findElement(By.cssSelector("button.btn_st.blue, button.확인"));
+                if (confirmButton.isDisplayed()) {
+                    confirmButton.click();
+                }
+            } catch (Exception e) {
+                log.debug("알림창이 표시되지 않았습니다: {}", e.getMessage());
+            }
+
+            log.info("부산교육청-학교 헬프센터 로그인 성공");
+
+        } catch (Exception e) {
+            log.error("부산교육청-학교 헬프센터 로그인 중 오류 발생: {}", e.getMessage());
+            log.error("오류 상세 정보:", e);
+            throw e;
+        }
+    }
+
+    @Override
+    protected void navigateToTargetPage() {
+        // 대상 페이지로 이동 (학교 수정요청 게시판)
+        driver.get(valueSettings.getBusanSchoolSchoolTargetUrl());
+        log.info("부산교육청-학교 수정요청 게시판 접속 완료");
+
+        // 페이지 로딩 대기
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector("table")));
+
+        // 페이지 완전 로딩 대기
+        waitForPageLoad();
+    }
+
+    @Override
+    protected void processPageData() {
+        // 현재 페이지 처리 (학교 수정요청 게시판)
+        processMultiplePages("table > tbody > tr");
+
+        // 유치원 수정요청 게시판으로 이동
+        driver.get(valueSettings.getBusanSchoolKindergartenTargetUrl());
+        log.info("부산교육청-유치원 수정요청 게시판 접속 완료");
+
+        // 페이지 로딩 대기
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector("table")));
+
+        // 페이지 완전 로딩 대기
+        waitForPageLoad();
+
+        // 유치원 수정요청 게시판 처리
+        processMultiplePages("table > tbody > tr");
+    }
+
+    @Override
+    protected boolean isCompleted(WebElement row) {
+        try {
+            // 완료 상태 확인 (이미지를 통해 확인)
+            List<WebElement> images = row.findElements(By.cssSelector("img[src*='btn_comp']"));
+            if (!images.isEmpty()) {
+                return true;
+            }
+
+            // 텍스트로 완료 상태 확인
+            String rowText = row.getText();
+            return rowText.contains("완료");
+        } catch (Exception e) {
+            log.debug("완료 상태 확인 오류: {}", e.getMessage());
+        }
+
+        return false;
+    }
+
+    @Override
+    protected String extractDateText(WebElement row) {
+        try {
+            // 날짜 셀 가져오기 (4번째 td가 날짜)
+            List<WebElement> cells = row.findElements(By.tagName("td"));
+            if (cells.size() >= 4) {
+                return cells.get(3).getText().trim();
+            }
+        } catch (Exception e) {
+            log.debug("날짜 텍스트 추출 오류: {}", e.getMessage());
+        }
+
+        return "";
+    }
+}

--- a/src/main/java/com/helpcentercrawl/crawler/impl/ChangwonCrawler.java
+++ b/src/main/java/com/helpcentercrawl/crawler/impl/ChangwonCrawler.java
@@ -47,6 +47,6 @@ public class ChangwonCrawler extends AbstractCrawler {
     @Override
     protected void processPageData() {
         // 단일 페이지 처리 공통 메서드 호출
-        processSinglePage("table#nttTable > tbody > tr");
+        processMultiplePages("table#nttTable > tbody > tr");
     }
 }

--- a/src/main/java/com/helpcentercrawl/crawler/impl/GneCrawler.java
+++ b/src/main/java/com/helpcentercrawl/crawler/impl/GneCrawler.java
@@ -96,6 +96,6 @@ public class GneCrawler extends AbstractCrawler {
     @Override
     protected void processPageData() {
         // 여러 페이지 처리 공통 메서드 호출 (최대 5페이지)
-        processMultiplePages("table tbody tr", ".pagination li a", 5);
+        processMultiplePages("table tbody tr");
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,10 @@ crawler:
       target-url: https://www.changwon.ac.kr/helpcenter/na/ntt/selectNttList.do?mi=13160&bbsId=3308
       username: ${CHANGWON_USERNAME}
       password: ${CHANGWON_PASSWORD}
+    busan-school:
+      name: 부산교육청-학교 헬프센터
+      login-url: https://school.busanedu.net/help/lo/login/loginPage.do
+      school-target-url: https://school.busanedu.net/help/na/ntt/selectNttList.do?mi=2344&bbsId=5048088
+      kindergarten-target-url: https://school.busanedu.net/help/na/ntt/selectNttList.do?mi=1854&bbsId=3000410
+      username: ${BUSAN_SCHOOL_USERNAME}
+      password: ${BUSAN_SCHOOL_PASSWORD}


### PR DESCRIPTION
## 개요
부산 교육청 지원센터(학교 이하 2개) 사이트의 크롤링 기능 추가

## 변경 사항
- 창원, 경남, 부산 지원센터 동일하게 n페이지까지 확인 가능하도록 공통 구현

## 테스트
순차적으로 애플리케이션이 정상적으로 빌드되고 실행되는 것을 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 부산교육청 학교 헬프센터 지원이 추가되어, 학교 및 유치원 관련 정보에 손쉽게 접근할 수 있습니다.
  - 관련 사이트 설정이 적용되어 서비스 범위가 확대되었습니다.

- **리팩토링**
  - 데이터 페이지 처리 방식을 개선하여 페이징 처리의 일관성과 성능이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->