### PR TITLE
feat: 타임존 및 크롤링 시간 기록 개선

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     ports:
       - "8081:8081"
     environment:
+      - TZ=Asia/Seoul  # 한국 시간대 설정
       - SPRING_PROFILES_ACTIVE=prod,secret
       # 데이터베이스 설정
       - SPRING_DATASOURCE_URL=${MYSQL_URL}
@@ -39,6 +40,8 @@ services:
   redis-main:
     image: redis:latest # Redis 최신 버전 사용
     container_name: redis-main # Redis 컨테이너 이름
+    environment:
+      - TZ=Asia/Seoul  # 한국 시간대 설정
     ports:
       - "6379:6379"
     restart: unless-stopped # 컨테이너가 중지되면 자동으로 재시작
@@ -49,13 +52,14 @@ services:
   mysql-db:
     image: mysql:8.0
     container_name: helpcenter-mysql-db # MySQL 컨테이너 이름
-    ports:
-      - "3306:3306"
     environment:
+      - TZ=Asia/Seoul  # 한국 시간대 설정
       - MYSQL_DATABASE=helpcenter # 데이터베이스 이름
       - MYSQL_USER=${MYSQL_USER} # 사용자
       - MYSQL_PASSWORD=${MYSQL_PASSWORD} # 비밀번호
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD} # 루트 비밀번호
+    ports:
+      - "3306:3306"
     volumes:
       - mysql-data:/var/lib/mysql
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci

--- a/script/run-test.sh
+++ b/script/run-test.sh
@@ -18,7 +18,7 @@ echo "Docker 컨테이너 중지 및 삭제..."
 docker compose down
 
 echo "Docker 이미지 빌드..."
-docker compose build --no-cache
+docker compose build
 
 echo "불필요한 이미지 정리..."
 docker image prune -f

--- a/src/main/java/com/helpcentercrawl/crawler/dto/CrawlSaveDto.java
+++ b/src/main/java/com/helpcentercrawl/crawler/dto/CrawlSaveDto.java
@@ -1,0 +1,43 @@
+package com.helpcentercrawl.crawler.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * packageName    : com.helpcentercrawl.crawler.dto
+ * fileName       : CrawlSaveDto
+ * author         : MinKyu Park
+ * date           : 2025-04-18
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2025-04-18        MinKyu Park       최초 생성
+ */
+@Getter
+@NoArgsConstructor
+public class CrawlSaveDto {
+	private String siteCode;
+	private String siteName;
+	private Integer completedCount;
+	private Integer notCompletedCount;
+	private Integer totalCount;
+	private LocalDate crawlDate;
+	private String lastUpdatedAt;
+
+	@Builder
+	public CrawlSaveDto(String siteCode, String siteName, Integer completedCount, Integer notCompletedCount,
+		Integer totalCount, LocalDate crawlDate, String lastUpdatedAt) {
+		this.siteCode = siteCode;
+		this.siteName = siteName;
+		this.completedCount = completedCount;
+		this.notCompletedCount = notCompletedCount;
+		this.totalCount = totalCount;
+		this.crawlDate = crawlDate;
+		this.lastUpdatedAt = lastUpdatedAt;
+	}
+}

--- a/src/main/java/com/helpcentercrawl/crawler/dto/CrawlSaveDto.java
+++ b/src/main/java/com/helpcentercrawl/crawler/dto/CrawlSaveDto.java
@@ -1,11 +1,12 @@
 package com.helpcentercrawl.crawler.dto;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /**
  * packageName    : com.helpcentercrawl.crawler.dto
@@ -27,11 +28,13 @@ public class CrawlSaveDto {
 	private Integer notCompletedCount;
 	private Integer totalCount;
 	private LocalDate crawlDate;
-	private String lastUpdatedAt;
+
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	private LocalDateTime lastUpdatedAt;
 
 	@Builder
 	public CrawlSaveDto(String siteCode, String siteName, Integer completedCount, Integer notCompletedCount,
-		Integer totalCount, LocalDate crawlDate, String lastUpdatedAt) {
+		Integer totalCount, LocalDate crawlDate, LocalDateTime lastUpdatedAt) {
 		this.siteCode = siteCode;
 		this.siteName = siteName;
 		this.completedCount = completedCount;

--- a/src/main/java/com/helpcentercrawl/crawler/model/CrawlRedisModel.java
+++ b/src/main/java/com/helpcentercrawl/crawler/model/CrawlRedisModel.java
@@ -1,0 +1,70 @@
+package com.helpcentercrawl.crawler.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.helpcentercrawl.crawler.dto.CrawlResultDto;
+import com.helpcentercrawl.crawler.dto.CrawlSaveDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.helpcentercrawl.crawler.model
+ * fileName       : CrawlRedisModel
+ * author         : MinKyu Park
+ * date           : 25. 4. 21.
+ * description    : Redis 저장 및 조회용 내부 직렬화 모델 CrawlSaveDto ↔ CrawlRedisModel ↔ CrawlResultDto
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 4. 21.        MinKyu Park       최초 생성
+ */
+@Getter
+@NoArgsConstructor
+public class CrawlRedisModel {
+    private String siteCode;
+    private String siteName;
+    private Integer completedCount;
+    private Integer notCompletedCount;
+    private Integer totalCount;
+    private LocalDate crawlDate;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime lastUpdatedAt;
+
+    @Builder
+    public CrawlRedisModel(String siteCode, String siteName, Integer completedCount, Integer notCompletedCount, Integer totalCount, LocalDate crawlDate, LocalDateTime lastUpdatedAt) {
+        this.siteCode = siteCode;
+        this.siteName = siteName;
+        this.completedCount = completedCount;
+        this.notCompletedCount = notCompletedCount;
+        this.totalCount = totalCount;
+        this.crawlDate = crawlDate;
+        this.lastUpdatedAt = lastUpdatedAt;
+    }
+
+
+    public static CrawlRedisModel fromSaveDto(CrawlSaveDto dto) {
+        return CrawlRedisModel.builder()
+                .siteCode(dto.getSiteCode())
+                .siteName(dto.getSiteName())
+                .completedCount(dto.getCompletedCount())
+                .notCompletedCount(dto.getNotCompletedCount())
+                .totalCount(dto.getTotalCount())
+                .crawlDate(dto.getCrawlDate())
+                .lastUpdatedAt(dto.getLastUpdatedAt())
+                .build();
+    }
+
+    public CrawlResultDto toResultDto() {
+        return CrawlResultDto.builder()
+                .siteCode(this.siteCode)
+                .siteName(this.siteName)
+                .completedCount(this.completedCount)
+                .notCompletedCount(this.notCompletedCount)
+                .totalCount(this.totalCount)
+                .crawlDate(this.crawlDate)
+                .build();
+    }
+}

--- a/src/main/java/com/helpcentercrawl/crawler/repository/CrawlResultRedisRepository.java
+++ b/src/main/java/com/helpcentercrawl/crawler/repository/CrawlResultRedisRepository.java
@@ -47,6 +47,10 @@ public class CrawlResultRedisRepository {
         String key = keyGenerator.generateKey(siteCode, date);
         String jsonValue = redisTemplate.opsForValue().get(key);
 
+        if (jsonValue == null) {
+            return null;
+        }
+
         try {
             return objectMapper.readValue(jsonValue, CrawlResultDto.class);
         } catch (JsonProcessingException e) {

--- a/src/main/java/com/helpcentercrawl/crawler/repository/CrawlResultRedisRepository.java
+++ b/src/main/java/com/helpcentercrawl/crawler/repository/CrawlResultRedisRepository.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.helpcentercrawl.common.util.KeyGenerator;
 import com.helpcentercrawl.crawler.dto.CrawlResultDto;
+import com.helpcentercrawl.crawler.dto.CrawlSaveDto;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -26,10 +28,10 @@ public class CrawlResultRedisRepository {
      * 크롤링 결과를 Redis에 저장
      * 키 형식: crawl:result:{사이트코드}:{yyyyMMdd}
      */
-    public void saveCrawlResult(CrawlResultDto crawlResultDto) {
+    public void saveCrawlResult(CrawlSaveDto crawlSaveDto) {
         try {
-            String key = keyGenerator.generateKey(crawlResultDto.getSiteCode(), crawlResultDto.getCrawlDate());
-            String jsonValue = objectMapper.writeValueAsString(crawlResultDto);
+            String key = keyGenerator.generateKey(crawlSaveDto.getSiteCode(), crawlSaveDto.getCrawlDate());
+            String jsonValue = objectMapper.writeValueAsString(crawlSaveDto);
             redisTemplate.opsForValue().set(key, jsonValue);
             redisTemplate.expire(key, EXPIRATION_DAYS, TimeUnit.DAYS);
         } catch (JsonProcessingException e) {
@@ -44,10 +46,6 @@ public class CrawlResultRedisRepository {
     public CrawlResultDto getCrawlResult(String siteCode, LocalDate date) {
         String key = keyGenerator.generateKey(siteCode, date);
         String jsonValue = redisTemplate.opsForValue().get(key);
-
-        if (jsonValue == null) {
-            return null;
-        }
 
         try {
             return objectMapper.readValue(jsonValue, CrawlResultDto.class);

--- a/src/main/java/com/helpcentercrawl/crawler/service/CrawlResultService.java
+++ b/src/main/java/com/helpcentercrawl/crawler/service/CrawlResultService.java
@@ -1,6 +1,7 @@
 package com.helpcentercrawl.crawler.service;
 
 import com.helpcentercrawl.crawler.dto.CrawlResultDto;
+import com.helpcentercrawl.crawler.dto.CrawlSaveDto;
 import com.helpcentercrawl.crawler.repository.CrawlResultRedisRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,10 +19,10 @@ public class CrawlResultService {
     /**
      * 크롤링 결과를 Redis에 저장
      */
-    public void saveCrawlResult(CrawlResultDto crawlResultDto) {
+    public void saveCrawlResult(CrawlSaveDto crawlSaveDto) {
         try {
-            crawlResultRedisRepository.saveCrawlResult(crawlResultDto);
-            log.info("Redis에 크롤링 결과 저장 완료: {}", crawlResultDto.getSiteName());
+            crawlResultRedisRepository.saveCrawlResult(crawlSaveDto);
+            log.info("Redis에 크롤링 결과 저장 완료: {}", crawlSaveDto.getSiteName());
         } catch (Exception e) {
             log.error("Redis에 크롤링 결과 저장 중 오류 발생: {}", e.getMessage(), e);
             throw e;

--- a/src/main/java/com/helpcentercrawl/dashboard/dto/DashboardResponseDto.java
+++ b/src/main/java/com/helpcentercrawl/dashboard/dto/DashboardResponseDto.java
@@ -1,8 +1,9 @@
 package com.helpcentercrawl.dashboard.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 public class DashboardResponseDto {
@@ -11,5 +12,6 @@ public class DashboardResponseDto {
     private Integer completedCount;
     private Integer notCompletedCount;
     private Integer totalCount;
-    private LocalDate crawlDate;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime lastUpdatedAt;
 }


### PR DESCRIPTION
- 모든 컨테이너에 한국 타임존(Asia/Seoul) 설정 추가
- LocalDateTime 역직렬화 시 포맷 패턴 지정 (@JsonFormat 어노테이션 추가)
- Redis 저장 시 중복 검사 로직의 NULL 안전성 개선
- 크롤링 결과 조회 API 응답에 마지막 업데이트 시간 포함


### 1차 변경 사항
- **시간 데이터 타입 개선**: `lastUpdatedAt` 필드 타입을 String에서 LocalDateTime으로 변경하여 날짜/시간 연산 및 비교가 용이하도록 함
- **시간대 명시적 지정**: 모든 시간 생성 시 `ZoneId.of("Asia/Seoul")`을 사용하여 한국 시간대 일관성 보장
- **정적 초기화 문제 해결**: 정적 필드로 시간을 초기화하던 방식에서 메서드 호출 시 시간을 생성하는 방식으로 변경

### 코드 구조 유지
- CrawlResultDto(조회용)와 CrawlSaveDto(저장용) 분리는 의도적 설계로, 관심사를 분리하기 위해 유지

### 2차 변경 사항
- **관심사 분리**: 각 DTO가 단일 책임을 갖도록 구조 개선
- **CrawlRedisModel 도입**: Redis 저장 데이터 구조를 명확하게 표현하는 전용 모델 클래스 추가
  - CrawlSaveDto: 애플리케이션→Redis 저장용 (컨트롤러→서비스)
  - CrawlRedisModel: 저장되는 데이터 구조를 표현하는 내부 모델 클래스
  - CrawlResultDto: Redis→애플리케이션 조회용 (서비스→컨트롤러)
- **캡슐화**: Redis 저장 구조 세부사항을 리포지토리 내부로 은닉
- **명시적 변환**: 데이터 변환 과정이 코드에 명확하게 표현되어 가독성 향상

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 크롤링 결과에 마지막 업데이트 시간을 기록하는 기능이 추가되었습니다.

- **버그 수정**
    - 서비스 및 대시보드에서 크롤링 결과의 날짜 필드가 마지막 업데이트 시간으로 변경되어 더 정확한 정보 제공이 가능합니다.

- **환경 설정**
    - Docker 서비스의 기본 시간대가 한국 표준시(Asia/Seoul)로 설정되었습니다.

- **기타**
    - Docker 빌드 스크립트가 캐시를 활용하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->