### PR TITLE
feat : 계정 관리 엔티티 및 서비스로직 추가

### DIFF
--- a/src/main/java/com/helpcentercrawl/HelpCenterCrawlApplication.java
+++ b/src/main/java/com/helpcentercrawl/HelpCenterCrawlApplication.java
@@ -10,6 +10,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableJpaAuditing
 public class HelpCenterCrawlApplication {
 
+//    TODO : 로컬에서 DB 설정 제외하고 실행하기 위해서 해야할 조치
+//           1. RedisConfig의 @Configuration 비활성화
+//           2. AbsstractCrawler의 RedisMaigration 실행부 비활성화
+//           3. RedisMigrationService 클래스 비활성화
+
     public static void main(String[] args) {
         SpringApplication.run(HelpCenterCrawlApplication.class, args);
     }

--- a/src/main/java/com/helpcentercrawl/account/controller/AccountController.java
+++ b/src/main/java/com/helpcentercrawl/account/controller/AccountController.java
@@ -1,0 +1,40 @@
+package com.helpcentercrawl.account.controller;
+
+import com.helpcentercrawl.account.dto.AccountResponseDto;
+import com.helpcentercrawl.account.service.AccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * packageName    : com.helpcentercrawl.account.controller
+ * fileName       : AccountController
+ * author         : MinKyu Park
+ * date           : 25. 4. 28.
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 4. 28.        MinKyu Park       최초 생성
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class AccountController {
+
+    private final AccountService accountService;
+
+    /**
+     * 계정 목록 조회
+     * @return List<AccountResponseDto>
+     */
+    @GetMapping("/accounts")
+    public ResponseEntity<List<AccountResponseDto>> getAccounts() {
+        return ResponseEntity.ok(accountService.getAccounts());
+    }
+
+}

--- a/src/main/java/com/helpcentercrawl/account/dto/AccountResponseDto.java
+++ b/src/main/java/com/helpcentercrawl/account/dto/AccountResponseDto.java
@@ -1,0 +1,31 @@
+package com.helpcentercrawl.account.dto;
+
+import com.helpcentercrawl.account.entity.Account;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * packageName    : com.helpcentercrawl.account.dto
+ * fileName       : AccountResponseDto
+ * author         : MinKyu Park
+ * date           : 25. 4. 28.
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 4. 28.        MinKyu Park       최초 생성
+ */
+@Getter
+@Builder
+public class AccountResponseDto {
+    private Long id;
+    private String siteCode;
+    private String loginId;
+
+    public static AccountResponseDto entityToDto(Account account) {
+        return AccountResponseDto.builder()
+                .siteCode(account.getSiteCode())
+                .loginId(account.getLoginId())
+                .build();
+    }
+}

--- a/src/main/java/com/helpcentercrawl/account/entity/Account.java
+++ b/src/main/java/com/helpcentercrawl/account/entity/Account.java
@@ -1,0 +1,41 @@
+package com.helpcentercrawl.account.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+/**
+ * packageName    : com.helpcentercrawl.account.entity
+ * fileName       : Account
+ * author         : MinKyu Park
+ * date           : 25. 4. 28.
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 4. 28.        MinKyu Park       최초 생성
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Account {
+    @Id
+    private Long id;
+    
+    @Comment("사이트 코드")
+    private String siteCode;
+    
+    @Comment("지원센터 로그인 아이디")
+    private String loginId;
+
+    @Builder
+    public Account(Long id, String siteCode, String loginId) {
+        this.id = id;
+        this.siteCode = siteCode;
+        this.loginId = loginId;
+    }
+}

--- a/src/main/java/com/helpcentercrawl/account/repository/AccountRepository.java
+++ b/src/main/java/com/helpcentercrawl/account/repository/AccountRepository.java
@@ -1,0 +1,20 @@
+package com.helpcentercrawl.account.repository;
+
+import com.helpcentercrawl.account.entity.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * packageName    : com.helpcentercrawl.account.repository
+ * fileName       : AccountRepository
+ * author         : MinKyu Park
+ * date           : 25. 4. 28.
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 4. 28.        MinKyu Park       최초 생성
+ */
+@Repository
+public interface AccountRepository extends JpaRepository<Account, Long> {
+}

--- a/src/main/java/com/helpcentercrawl/account/service/AccountService.java
+++ b/src/main/java/com/helpcentercrawl/account/service/AccountService.java
@@ -1,0 +1,40 @@
+package com.helpcentercrawl.account.service;
+
+import com.helpcentercrawl.account.dto.AccountResponseDto;
+import com.helpcentercrawl.account.entity.Account;
+import com.helpcentercrawl.account.repository.AccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * packageName    : com.helpcentercrawl.account.service
+ * fileName       : AccountService
+ * author         : MinKyu Park
+ * date           : 25. 4. 28.
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 4. 28.        MinKyu Park       최초 생성
+ */
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+    private final AccountRepository accountRepository;
+
+
+    /**
+     * 계정 목록 조회
+     * @return List<AccountResponseDto>
+     */
+    public List<AccountResponseDto> getAccounts() {
+
+        List<Account> accounts = accountRepository.findAll();
+
+        return accounts.stream()
+                .map(AccountResponseDto::entityToDto)
+                .toList();
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,9 +28,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
     properties:
       hibernate:
-        format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
     open-in-view: false

--- a/src/test/java/com/helpcentercrawl/account/controller/AccountControllerTest.java
+++ b/src/test/java/com/helpcentercrawl/account/controller/AccountControllerTest.java
@@ -1,0 +1,100 @@
+package com.helpcentercrawl.account.controller;
+
+import com.helpcentercrawl.account.dto.AccountResponseDto;
+import com.helpcentercrawl.account.service.AccountService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * packageName    : com.helpcentercrawl.account.controller
+ * fileName       : AccountControllerTest
+ * author         : MinKyu Park
+ * date           : 25. 4. 28.
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 4. 28.        MinKyu Park       최초 생성
+ */
+@ExtendWith(MockitoExtension.class)
+class AccountControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private AccountService accountService;
+
+    @InjectMocks
+    private AccountController accountController;
+
+
+    @BeforeEach
+    void setup() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(accountController)
+                .build();
+    }
+
+    @Test
+    @DisplayName("계정 목록 조회 API가 정상적으로 동작한다")
+    void getAccountsTest() throws Exception {
+        // given
+        AccountResponseDto account1 = AccountResponseDto.builder().id(1L)
+                .siteCode("site1")
+                .loginId("user1")
+                .build();
+        AccountResponseDto account2 = AccountResponseDto.builder().id(2L)
+                .siteCode("site2")
+                .loginId("user2")
+                .build();
+
+        List<AccountResponseDto> accounts = Arrays.asList(account1, account2);
+
+        when(accountService.getAccounts()).thenReturn(accounts);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/accounts")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].siteCode").value("site1"))
+                .andExpect(jsonPath("$[0].loginId").value("user1"))
+                .andExpect(jsonPath("$[1].id").value(2))
+                .andExpect(jsonPath("$[1].siteCode").value("site2"))
+                .andExpect(jsonPath("$[1].loginId").value("user2"));
+
+        verify(accountService, times(1)).getAccounts();
+    }
+
+    @Test
+    @DisplayName("계정 정보가 없을 경우 빈 배열을 반환한다")
+    void getEmptyAccountsTest() throws Exception {
+        // given
+        when(accountService.getAccounts()).thenReturn(List.of());
+
+        // when & then
+        mockMvc.perform(get("/api/v1/accounts")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+
+        verify(accountService, times(1)).getAccounts();
+    }
+}

--- a/src/test/java/com/helpcentercrawl/account/repository/AccountRepositoryTest.java
+++ b/src/test/java/com/helpcentercrawl/account/repository/AccountRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.helpcentercrawl.account.repository;
+
+import com.helpcentercrawl.account.entity.Account;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * packageName    : com.helpcentercrawl.account.repository
+ * fileName       : AccountRepositoryTest
+ * author         : MinKyu Park
+ * date           : 25. 4. 28.
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 4. 28.        MinKyu Park       최초 생성
+ */
+@DataJpaTest
+class AccountRepositoryTest {
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Test
+    @DisplayName("findAll 메서드는 저장된 모든 계정을 조회한다")
+    @Sql("/sql/account-test-data.sql")
+    void findAllTest() {
+        // when
+        List<Account> accounts = accountRepository.findAll();
+
+        // then
+        assertThat(accounts).isNotEmpty();
+        assertThat(accounts).hasSize(3);
+        assertThat(accounts.get(0).getSiteCode()).isEqualTo("site1");
+    }
+
+    // 추가 테스트 메서드
+    @Test
+    @DisplayName("Repository가 비어있을 때 findAll은 빈 리스트를 반환한다")
+    void findAllEmptyTest() {
+        // given
+        accountRepository.deleteAll(); // 기존 데이터 모두 삭제
+
+        // when
+        List<Account> accounts = accountRepository.findAll();
+
+        // then
+        assertThat(accounts).isEmpty();
+    }
+}

--- a/src/test/java/com/helpcentercrawl/account/service/AccountServiceTest.java
+++ b/src/test/java/com/helpcentercrawl/account/service/AccountServiceTest.java
@@ -1,0 +1,85 @@
+package com.helpcentercrawl.account.service;
+
+import com.helpcentercrawl.account.dto.AccountResponseDto;
+import com.helpcentercrawl.account.entity.Account;
+import com.helpcentercrawl.account.repository.AccountRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * packageName    : com.helpcentercrawl.account.service
+ * fileName       : AccountServiceTest
+ * author         : MinKyu Park
+ * date           : 25. 4. 28.
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 4. 28.        MinKyu Park       최초 생성
+ */
+@ExtendWith(MockitoExtension.class)
+class AccountServiceTest {
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @InjectMocks
+    private AccountService accountService;
+
+    @Test
+    @DisplayName("모든 계정 정보를 조회한다")
+    void getAllAccounts() {
+        // given
+        Account account1 = createAccount(1L, "site1", "user1");
+        Account account2 = createAccount(2L, "site2", "user2");
+        List<Account> accounts = Arrays.asList(account1, account2);
+
+        when(accountRepository.findAll()).thenReturn(accounts);
+
+        // when
+        List<AccountResponseDto> result = accountService.getAccounts();
+
+        // then
+        assertThat(result).hasSize(2);
+//        assertThat(result.get(0).getId()).isEqualTo(1L);
+        assertThat(result.get(0).getSiteCode()).isEqualTo("site1");
+        assertThat(result.get(0).getLoginId()).isEqualTo("user1");
+//        assertThat(result.get(1).getId()).isEqualTo(2L);
+        assertThat(result.get(1).getSiteCode()).isEqualTo("site2");
+        assertThat(result.get(1).getLoginId()).isEqualTo("user2");
+
+        verify(accountRepository, times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("계정 정보가 없을 경우 빈 리스트를 반환한다")
+    void getEmptyAccounts() {
+        // given
+        when(accountRepository.findAll()).thenReturn(List.of());
+
+        // when
+        List<AccountResponseDto> result = accountService.getAccounts();
+
+        // then
+        assertThat(result).isEmpty();
+        verify(accountRepository, times(1)).findAll();
+    }
+
+    private Account createAccount(Long id, String siteCode, String loginId) {
+        return Account.builder()
+                .id(id)
+                .siteCode(siteCode)
+                .loginId(loginId)
+                .build();
+    }
+}

--- a/src/test/resources/sql/account-test-data.sql
+++ b/src/test/resources/sql/account-test-data.sql
@@ -1,0 +1,4 @@
+-- 테스트용 계정 데이터 삽입
+INSERT INTO account (id, site_code, login_id) VALUES (1, 'site1', 'user1');
+INSERT INTO account (id, site_code, login_id) VALUES (2, 'site2', 'user2');
+INSERT INTO account (id, site_code, login_id) VALUES (3, 'site3', 'user3');


### PR DESCRIPTION
## 🛠️ 주요 변경 내용
- 크롤링 대시보드에 사이트별 사용 계정 정보 확인 기능 추가

## ❓ 변경 이유
- 중복된 계정을 사용하지 않기 위함
- 각 사이트별 계정 현황을 한 눈에 파악하기 위한 기능 필요

## 🔄 상세 작업 내역
- Account 엔티티 추가 및 JPA Repository 구현
- 계정 정보 조회를 위한 Controller, Service 레이어 개발
- 단위 테스트 코드 작성

## ✅ 테스트 및 검증 방법
- 로컬 개발 환경에서 기능 동작 테스트 완료
- 서비스, 리포지토리, 컨트롤러 각 레이어별 단위 테스트 작성


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 계정 목록을 조회할 수 있는 REST API 엔드포인트(`/api/v1/accounts`)가 추가되었습니다.
- **테스트**
    - 계정 조회 API, 서비스, 저장소에 대한 단위 및 통합 테스트가 추가되었습니다.
- **문서**
    - 주요 클래스와 메서드에 Javadoc 주석이 추가되었습니다.
- **스타일**
    - 프로덕션 환경에서 Hibernate SQL 로그 및 포맷 출력 설정이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->