### PR TITLE
fix: 부산행정 로그인 시 두 개의 Alert 처리 로직 추가

### DIFF
--- a/src/main/java/com/helpcentercrawl/crawler/impl/BusanAdminCrawler.java
+++ b/src/main/java/com/helpcentercrawl/crawler/impl/BusanAdminCrawler.java
@@ -5,6 +5,8 @@ import com.helpcentercrawl.crawler.core.AbstractCrawler;
 import com.helpcentercrawl.crawler.model.LoginModel;
 import com.helpcentercrawl.crawler.service.CrawlResultService;
 import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.Alert;
+import org.openqa.selenium.NoAlertPresentException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -48,7 +50,10 @@ public class BusanAdminCrawler extends AbstractCrawler {
                 .username(valueSettings.getBusanAdminUsername())
                 .password(valueSettings.getBusanAdminPassword())
                 .jsLogin(false)
-                .successCondition(ExpectedConditions.urlContains("main"))
+                .successCondition(ExpectedConditions.or(
+                        ExpectedConditions.urlContains("main"),
+                        ExpectedConditions.urlContains("changePassword")
+                ))
                 .build();
     }
 
@@ -58,14 +63,37 @@ public class BusanAdminCrawler extends AbstractCrawler {
     }
 
     @Override
-    protected void handlePopup() {
+    protected void handlePopup() throws InterruptedException {
         try {
+            // 첫 번째 Alert 처리
             WebDriverWait alertWait = new WebDriverWait(driver, Duration.ofSeconds(3));
             alertWait.until(ExpectedConditions.alertIsPresent());
 
-            driver.switchTo().alert().accept();
-        } catch (TimeoutException ignored) {
-            log.debug("Alert 창이 나타나지 않았습니다.");
+            Alert firstAlert = driver.switchTo().alert();
+            String firstAlertText = firstAlert.getText();
+            log.info("부산행정 - 첫 번째 Alert: {}", firstAlertText);
+            firstAlert.accept();
+
+            Thread.sleep(500); // 잠시 대기
+
+            // 두 번째 Alert 처리
+            try {
+                alertWait.until(ExpectedConditions.alertIsPresent());
+                Alert secondAlert = driver.switchTo().alert();
+                String secondAlertText = secondAlert.getText();
+                log.info("부산행정 - 두 번째 Alert: {}", secondAlertText);
+                secondAlert.accept();
+
+                log.info("부산행정 - 두 개의 Alert 처리 완료");
+
+            } catch (TimeoutException e) {
+                log.debug("부산행정 - 두 번째 Alert이 나타나지 않았습니다.");
+            }
+
+        } catch (TimeoutException e) {
+            log.debug("부산행정 - Alert 창이 나타나지 않았습니다.");
+        } catch (NoAlertPresentException e) {
+            log.debug("부산행정 - Alert이 존재하지 않습니다.");
         }
     }
 

--- a/src/main/java/com/helpcentercrawl/crawler/impl/BusanAdminCrawler.java
+++ b/src/main/java/com/helpcentercrawl/crawler/impl/BusanAdminCrawler.java
@@ -65,20 +65,18 @@ public class BusanAdminCrawler extends AbstractCrawler {
     @Override
     protected void handlePopup() throws InterruptedException {
         try {
-            // 첫 번째 Alert 처리
-            WebDriverWait alertWait = new WebDriverWait(driver, Duration.ofSeconds(3));
-            alertWait.until(ExpectedConditions.alertIsPresent());
+            WebDriverWait firstAlertWait = new WebDriverWait(driver, Duration.ofSeconds(5));
+            firstAlertWait.until(ExpectedConditions.alertIsPresent());
 
             Alert firstAlert = driver.switchTo().alert();
             String firstAlertText = firstAlert.getText();
             log.info("부산행정 - 첫 번째 Alert: {}", firstAlertText);
             firstAlert.accept();
 
-            Thread.sleep(500); // 잠시 대기
-
-            // 두 번째 Alert 처리
             try {
-                alertWait.until(ExpectedConditions.alertIsPresent());
+                WebDriverWait secondAlertWait = new WebDriverWait(driver, Duration.ofSeconds(2));
+                secondAlertWait.until(ExpectedConditions.alertIsPresent());
+
                 Alert secondAlert = driver.switchTo().alert();
                 String secondAlertText = secondAlert.getText();
                 log.info("부산행정 - 두 번째 Alert: {}", secondAlertText);
@@ -91,7 +89,7 @@ public class BusanAdminCrawler extends AbstractCrawler {
             }
 
         } catch (TimeoutException e) {
-            log.debug("부산행정 - Alert 창이 나타나지 않았습니다.");
+            log.debug("부산행정 - 첫 번째 Alert 창이 나타나지 않았습니다.");
         } catch (NoAlertPresentException e) {
             log.debug("부산행정 - Alert이 존재하지 않습니다.");
         }


### PR DESCRIPTION
## 🛠️ 주요 변경 내용
- 부산행정 크롤러의 JavaScript Alert 처리 로직 개선
- 로그인 성공 조건에 비밀번호 변경 페이지 추가

## ❓ 변경 이유
- 부산행정 사이트 로그인 시 발생하는 2개의 연속적인 Alert을 처리하지 못해 크롤링이 지속적으로 실패
- `UnhandledAlertException` 발생으로 인한 데이터 수집 중단 문제 해결 필요

## 🔄 상세 작업 내역
- `BusanAdminCrawler.handlePopup()` 메서드 수정
  - 첫 번째 Alert 처리 후 두 번째 Alert 대기 및 처리 로직 추가
- `BusanAdminCrawler.getLoginModel()` 메서드 수정
  - `successCondition`에 `urlContains("changePassword")` 조건 추가
  - 기존 `main` URL과 비밀번호 변경 페이지 모두 로그인 성공으로 인식

## ✅ 테스트 및 검증 방법
- 로컬(dev) 환경에서 부산행정 크롤러 단독 실행 테스트
- Alert 2개 연속 발생 시나리오 처리 확인
- 비밀번호 변경 페이지 이동 후 타겟 URL 접근 확인
- 전체 크롤링 스케줄러 실행하여 다른 크롤러에 영향 없음 확인
- 부산행정 크롤링 데이터 수집 성공 여부 확인

---

Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
    - 로그인 성공 조건이 확장되어, "main" 또는 "changePassword"가 포함된 URL 모두를 로그인 성공으로 인식합니다.
    - 팝업 알림 처리 기능이 개선되어, 최대 두 번 연속으로 나타나는 알림창도 정상적으로 처리됩니다.
    - 알림창이 없거나 두 번째 알림창이 나타나지 않는 경우에도 오류 없이 처리됩니다.
    - 데이터 처리 중 예기치 않은 브라우저 알림이 나타날 경우 자동으로 감지하고 처리하여 안정성을 향상시켰습니다.
    - 알림 발생 시 해당 행을 건너뛰고 로그를 남기는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->