### PR TITLE
feat: ELK 로그 전송 설정 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
 
     // Jakarta 어노테이션 API (런타임용)
     implementation 'jakarta.annotation:jakarta.annotation-api'
+
+    //ELK
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 }
 
 clean {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,7 +4,7 @@ server:
 # 크롤링 실행 주기 설정 (ms 단위)
 scheduler:
   crawler:
-    cron: 0 0/3 8-18 * * MON-FRI  # 월요일 ~ 금요일 08시 부터 18시까지 3분마다 실행
+    cron: 0 0/10 8-18 * * MON-FRI  # 월요일 ~ 금요일 08시 부터 18시까지 10분마다 실행
 
 
 spring:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -27,7 +27,7 @@
         <keepAliveDuration>5 minutes</keepAliveDuration>
         <writeTimeout>5000</writeTimeout>
         <includeCallerData>false</includeCallerData>
-        <queueSize>256</queueSize>
+        <queueSize>100</queueSize>
     </appender>
 
     <!-- B 컴퓨터로만 전송, A 컴퓨터에는 아무것도 저장 안 함 -->

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- ELK 서버로만 로그 전송 -->
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>${ELK_LOGSTASH_HOST:-localhost}:${ELK_LOGSTASH_PORT:-5000}</destination>
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp/>
+                <version/>
+                <logLevel/>
+                <message/>
+                <mdc/>
+                <arguments/>
+                <stackTrace/>
+                <loggerName/>
+                <pattern>
+                    <pattern>
+                        {
+                        "app": "${ELK_APP_NAME:-helpcentercrawl}",
+                        "server": "${ELK_SERVER_NAME:-unknown-server}"
+                        }
+                    </pattern>
+                </pattern>
+            </providers>
+        </encoder>
+        <connectionTimeout>5000</connectionTimeout>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
+        <writeTimeout>5000</writeTimeout>
+        <includeCallerData>false</includeCallerData>
+        <queueSize>256</queueSize>
+    </appender>
+
+    <!-- B 컴퓨터로만 전송, A 컴퓨터에는 아무것도 저장 안 함 -->
+    <root level="ERROR">
+        <appender-ref ref="LOGSTASH"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## 🛠️ 주요 변경 내용
- 배포 서버 로그 저장 완전 차단, ELK 서버로만 전송
- Docker 컨테이너 로그 비활성화 (`logging.driver: "none"`)
- ELK 전송 실패 시에도 배포 서버에 로그 미저장

## ❓ 변경 이유
- 공용 배포 서버 디스크 사용량 최소화 (연간 200MB 예상 → 0MB)
- 중앙 집중식 로그 관리로 모니터링 효율성 증대

## 🔄 상세 작업 내역
- **logback-spring.xml**: FILE/CONSOLE appender 제거, LogstashTcpSocketAppender만 사용
- **docker-compose.yml**: `logging.driver: "none"` 설정, ELK 환경변수 추가
- **ELK 전송 설정**: 큐 크기 100개, 5초 타임아웃, 5분 재연결
- **로그 레벨**: ERROR만 수집하여 중요 로그만 전송

## ✅ 테스트 및 검증 방법
- **배포 서버**: Docker Desktop에서 로그 읽기 불가 확인, `/app/logs/` 폴더 미생성
- **장애 복구**: ELK 서버 다운 시 큐 저장 → 재시작 시 자동 전송 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 로그가 ELK 스택(Logstash)으로 전송되도록 로그 설정이 추가되었습니다.
- **변경 사항**
  - 크롤러 스케줄러의 실행 주기가 평일 오전 8시~오후 6시 동안 3분마다에서 10분마다로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->